### PR TITLE
Detect iphone simulator PLATFORM_NAME

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -30,7 +30,8 @@ if (process.env.DONT_COMPILE) {
   process.exit(0)
 }
 
-if (process.env.PLATFORM_NAME === 'iphoneos') {
+var PLATFORM_NAME = process.env.PLATFORM_NAME
+if (PLATFORM_NAME === 'iphoneos' || PLATFORM_NAME === 'iphonesimulator') {
   buildIOS()
 } else {
   buildAndroid('arm', () => {

--- a/preinstall.js
+++ b/preinstall.js
@@ -63,7 +63,8 @@ if (process.env.DONT_COMPILE) {
   process.exit(0)
 }
 
-if (process.env.PLATFORM_NAME === 'iphoneos') {
+var PLATFORM_NAME = process.env.PLATFORM_NAME
+if (PLATFORM_NAME === 'iphoneos' || PLATFORM_NAME === 'iphonesimulator') {
   buildIOS()
 } else {
   buildAndroid('arm', () => {


### PR DESCRIPTION
This fixes issues with xcode not building sodium.node for the correct arch when running on a simulator and instead compiling for iOS. 😁